### PR TITLE
About section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 # Top 10 FAIR Data & Software Things
 
-Top 10 FAIR Data & Software Things is hosted by Library Carpentry and maintained by the Sprinters.
+The Top 10 FAIR Data & Software Things are brief guides (stand alone,
+self paced training materials), called "Things", that can be used by
+the research community to understand how they can make their research
+(data and software) more [FAIR (Findable, Accessible, Interoperable
+and Reusable)](https://www.go-fair.org/fair-principles/).
+
+The Top 10 FAIR Data & Software Things is hosted by Library Carpentry and maintained by the Sprinters.
 
 ## Lead Maintainers
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 
 # Basic
 name:               "Top 10 FAIR Data & Software Things"
-description:        "The Top 10 FAIR Data & Software Global Sprint was held online over the course of two-days (29-30 November 2018), where participants from around the world were invited to develop brief guides (stand alone, self paced training materials), called “Things”, that can be used by the research community to understand FAIR in different contexts as well as some initial steps to consider. "
+description:        "The Top 10 FAIR Data & Software Things are brief guides (stand alone, self paced training materials), called "Things", that can be used by the research community to understand how they can make their research (data and software) more FAIR (Findable, Accessible, Interoperable and Reusable)."
 
 # jekyll-seo-tag, see: http://www.rubydoc.info/gems/jekyll-seo-tag/1.2.0
 url:                "https://librarycarpentry.org/Top-10-FAIR/"


### PR DESCRIPTION
This adds a short descriptive paragraph to both the description (HTML meta description tag in the rendered output) and the README file.

This is a follow-up from #20 . I've simply copy-pasted the text from the front page (which was effectively introduced in #20 ), since that seems perfect for this already, and makes it more consistent overall.
