### PR TITLE
Make 'about' and 'license' links relative

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,13 +26,13 @@ markdown:           kramdown
 # Navigation
 nav:
   - name:           "About"
-    href:           "/Top-10-FAIR/about"
+    href:           "about"
   - name:           "GitHub Repository"
     href:           "https://github.com/LibraryCarpentry/Top-10-FAIR"
   - name:           "Download/Cite"
     href:           "http://doi.org/10.5281/zenodo.3409968"
   - name:           "License"
-    href:           "/Top-10-FAIR/license"
+    href:           "license"
   - name:           "#Top10FAIR"
     href:           "https://twitter.com/search?f=tweets&vertical=default&q=%23top10fair&src=typd&lang=en"
 


### PR DESCRIPTION
Changing the links to be relative makes it slighty easier to port things
in the future (e.g., in case Top-10-FAIR gets its own domain), and for
testing locally.