### PR TITLE
Added TCGA to Biomedical Sciences Repos in Imaging guide

### DIFF
--- a/_posts/2019-06-27-imaging.md
+++ b/_posts/2019-06-27-imaging.md
@@ -355,6 +355,7 @@ Data repositories [recommended by the Scientific Data Journal](https://www.natur
 *   [DeepLesion, a project from the NIH](https://nihcc.app.box.com/v/DeepLesion) that released a dataset of 32,000 CT chest images with different type of lesions.
 *   Content manager [SciCrunch](https://scicrunch.org), a data sharing and display platform and training materials for searching and sharing in biomedical sciences across hundreds of databases.
 *   [BioStudies](https://www.ebi.ac.uk/biostudies/) The database can accept a wide range of types of studies, and its used to describe it. It also enables manuscript authors to submit supplementary information and link to it from the publication.
+*   The Cancer Genome Atlas ([TCGA](https://www.cancer.gov/about-nci/organization/ccg/research/structural-genomics/tcga)) is a National Cancer Institute (NCI) project aggregating genomic and imaging data from over 20,000 patient samples and 33 cancer types. TCGA hosts de-identified histopathology images across a range of cancer types, in the SVS file format. Images are made available using the [Genomic Data Commons Data Portal](https://portal.gdc.cancer.gov/) under the data category "Biospecimen".
 
 ### Non-domain specific
 *   Australian Data Archive [ADA](https://ada.edu.au/) it has a Core Trust Seal Certification. It is mainly for digital data relating to social, political and economic affairs which might include social and health studies.


### PR DESCRIPTION
Added The Cancer Genome Atlas (TCGA) as a repository to the Imaging Biomedical sciences repository list. TCGA is often overlooked as an imaging repository as it is predominately a genomics repository, but it also hosts histopathology images across a wide range of cancer sites, and includes, on its parent host (Genomic Data Commons), an embedded OpenSeadragon multi-resolution viewer for exploring the images before download. 